### PR TITLE
Add Basic Syntax Highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12144,7 +12144,7 @@
         },
         "vscode-aeon": {
             "name": "aeon-lang",
-            "version": "0.0.1",
+            "version": "0.0.5",
             "dependencies": {
                 "@vscode-elements/elements": "^1.7.1",
                 "@vscode/codicons": "^0.0.36",
@@ -12159,6 +12159,7 @@
                 "@types/vscode": "^1.73.0",
                 "@vscode/vsce": "^2.21.1",
                 "eslint": "^9.13.0",
+                "js-yaml": "^4.1.0",
                 "ovsx": "^0.9.1",
                 "typescript": "^5.7.2",
                 "typescript-eslint": "^8.16.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "eslint": "^8.45.0",
                 "eslint-config-prettier": "^9.1.0",
                 "eslint-plugin-react-hooks": "^5.1.0",
+                "js-yaml": "^4.1.0",
                 "lerna": "^8.1.2",
                 "lint-staged": "^15.2.2",
                 "prettier": "^3.2.5",
@@ -12159,7 +12160,6 @@
                 "@types/vscode": "^1.73.0",
                 "@vscode/vsce": "^2.21.1",
                 "eslint": "^9.13.0",
-                "js-yaml": "^4.1.0",
                 "ovsx": "^0.9.1",
                 "typescript": "^5.7.2",
                 "typescript-eslint": "^8.16.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
         "test": "lerna run --stream test",
         "watch": "lerna run --parallel --stream watch",
         "watchTest": "lerna run --parallel --stream watchTest",
-        "lint": "eslint -c .eslintrc.js \"vscode-aeon/src/extension.ts\""
+        "lint": "eslint -c .eslintrc.js \"vscode-aeon/src/extension.ts\"",
+		"yaml2json" : "npx js-yaml vscode-aeon/syntaxes/aeon.yaml > vscode-aeon/syntaxes/aeon.json"
     },
     "workspaces": [
         "vscode-aeon"
@@ -21,7 +22,8 @@
         "lint-staged": "^15.2.2",
         "prettier": "^3.2.5",
         "prettier-plugin-organize-imports": "^4.1.0",
-        "typescript": "^5.4.5"
+        "typescript": "^5.4.5",
+		"js-yaml": "^4.1.0"
     },
     "lint-staged": {
         "*.{ts,tsx,js}": [

--- a/vscode-aeon/package.json
+++ b/vscode-aeon/package.json
@@ -51,7 +51,10 @@
             {
                 "language": "aeon",
                 "scopeName": "source.aeon",
-                "path": "./syntaxes/aeon.json"
+                "path": "./syntaxes/aeon.json",
+				"embeddedLanguages": {
+                    "source.python": "python"
+                }
             }
         ]
     },
@@ -87,5 +90,9 @@
         "publisherDisplayName": "AlcidesFonseca",
         "publisherId": "cad44106-bddd-6cd4-a711-3354f600f23c",
         "isPreReleaseVersion": false
-    }
+    },
+	"embeddedLanguages": {
+                    "source.python": "python",
+                    "meta.embedded.block.python": "python"
+      }
 }

--- a/vscode-aeon/syntaxes/aeon.json
+++ b/vscode-aeon/syntaxes/aeon.json
@@ -1,238 +1,209 @@
 {
-    "name": "Aeon",
-    "scopeName": "source.aeon",
-    "fileTypes": [],
-    "patterns": [
-        {
-            "include": "#comments"
-        },
-        {
-            "match": "\\b(Prop|Type|Sort)\\b",
-            "name": "storage.type.lean4"
-        },
-        {
-            "match": "\\battribute\\b\\s*\\[[^\\]]*\\]",
-            "name": "storage.modifier.lean4"
-        },
-        {
-            "match": "@\\[[^\\]]*\\]",
-            "name": "storage.modifier.lean4"
-        },
-        {
-            "match": "\\b(?<!\\.)(global|local|scoped|partial|unsafe|private|protected|noncomputable)(?!\\.)\\b",
-            "name": "storage.modifier.lean4"
-        },
-        {
-            "match": "\\b(sorry|admit|stop)\\b",
-            "name": "invalid.illegal.lean4"
-        },
-        {
-            "match": "#(print|eval|reduce|check|check_failure)\\b",
-            "name": "keyword.other.lean4"
-        },
-        {
-            "match": "\\bderiving\\s+instance\\b",
-            "name": "keyword.other.command.lean4"
-        },
-        {
-            "begin": "\\b(?<!\\.)(inductive|coinductive|structure|theorem|axiom|abbrev|lemma|def|instance|class|constant)\\b\\s+(\\{[^}]*\\})?",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.other.definitioncommand.lean4"
-                }
-            },
-            "patterns": [
-                {
-                    "include": "#comments"
-                },
-                {
-                    "include": "#definitionName"
-                },
-                {
-                    "match": ","
-                }
-            ],
-            "end": "(?=\\bwith\\b|\\bextends\\b|\\bwhere\\b|[:\\|\\(\\[\\{⦃<>])",
-            "name": "meta.definitioncommand.lean4"
-        },
-        {
-            "match": "\\b(?<!\\.)(theorem|show|have|from|suffices|nomatch|def|class|structure|instance|set_option|initialize|builtin_initialize|example|inductive|coinductive|axiom|constant|universe|universes|variable|variables|import|open|export|theory|prelude|renaming|hiding|exposing|do|by|let|extends|mutual|mut|where|rec|syntax|macro_rules|macro|deriving|fun|section|namespace|end|infix|infixl|infixr|postfix|prefix|notation|abbrev|if|then|else|calc|match|with|for|in|unless|try|catch|finally|return|continue|break)(?!\\.)\\b",
-            "name": "keyword.other.lean4"
-        },
-        {
-            "begin": "«",
-            "end": "»",
-            "contentName": "entity.name.lean4"
-        },
-        {
-            "begin": "(s!)\"",
-            "end": "\"",
-            "name": "string.interpolated.lean4",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.other.lean4"
-                }
-            },
-            "patterns": [
-                {
-                    "begin": "(\\{)",
-                    "end": "(\\})",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "keyword.other.lean4"
-                        }
-                    },
-                    "endCaptures": {
-                        "1": {
-                            "name": "keyword.other.lean4"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "$self"
-                        }
-                    ]
-                },
-                {
-                    "match": "\\\\[\\\\\"ntr']",
-                    "name": "constant.character.escape.lean4"
-                },
-                {
-                    "match": "\\\\x[0-9A-Fa-f][0-9A-Fa-f]",
-                    "name": "constant.character.escape.lean4"
-                },
-                {
-                    "match": "\\\\u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]",
-                    "name": "constant.character.escape.lean4"
-                }
-            ]
-        },
-        {
-            "begin": "\"",
-            "end": "\"",
-            "name": "string.quoted.double.lean4",
-            "patterns": [
-                {
-                    "match": "\\\\[\\\\\"ntr']",
-                    "name": "constant.character.escape.lean4"
-                },
-                {
-                    "match": "\\\\x[0-9A-Fa-f][0-9A-Fa-f]",
-                    "name": "constant.character.escape.lean4"
-                },
-                {
-                    "match": "\\\\u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]",
-                    "name": "constant.character.escape.lean4"
-                }
-            ]
-        },
-        {
-            "name": "constant.language.lean4",
-            "match": "\\b(true|false)\\b"
-        },
-        {
-            "name": "string.quoted.single.lean4",
-            "match": "'[^\\\\']'"
-        },
-        {
-            "name": "string.quoted.single.lean4",
-            "match": "'(\\\\(x[0-9A-Fa-f][0-9A-Fa-f]|u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]|.))'",
-            "captures": {
-                "1": {
-                    "name": "constant.character.escape.lean4"
-                }
-            }
-        },
-        {
-            "match": "`+[^\\[(]\\S+",
-            "name": "entity.name.lean4"
-        },
-        {
-            "match": "\\b([0-9]+|0([xX][0-9a-fA-F]+)|[-]?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?)\\b",
-            "name": "constant.numeric.lean4"
-        }
-    ],
-    "repository": {
-        "definitionName": {
-            "patterns": [
-                {
-                    "match": "\\b[^:«»\\(\\)\\{\\}[:space:]=→λ∀?][^:«»\\(\\)\\{\\}[:space:]]*",
-                    "name": "entity.name.function.lean4"
-                },
-                {
-                    "begin": "«",
-                    "end": "»",
-                    "contentName": "entity.name.function.lean4"
-                }
-            ]
-        },
-        "dashComment": {
-            "begin": "--",
-            "end": "$",
-            "name": "comment.line.double-dash.lean4",
-            "patterns": [
-                {
-                    "include": "source.lean4.markdown"
-                }
-            ]
-        },
-        "docComment": {
-            "begin": "/--",
-            "end": "-/",
-            "name": "comment.block.documentation.lean4",
-            "patterns": [
-                {
-                    "include": "source.lean4.markdown"
-                },
-                {
-                    "include": "#blockComment"
-                }
-            ]
-        },
-        "modDocComment": {
-            "begin": "/-!",
-            "end": "-/",
-            "name": "comment.block.documentation.lean4",
-            "patterns": [
-                {
-                    "include": "source.lean4.markdown"
-                },
-                {
-                    "include": "#blockComment"
-                }
-            ]
-        },
-        "blockComment": {
-            "begin": "/-",
-            "end": "-/",
-            "name": "comment.block.lean4",
-            "patterns": [
-                {
-                    "include": "source.lean4.markdown"
-                },
-                {
-                    "include": "#blockComment"
-                }
-            ]
-        },
-        "comments": {
-            "patterns": [
-                {
-                    "include": "#dashComment"
-                },
-                {
-                    "include": "#docComment"
-                },
-                {
-                    "include": "#stringBlock"
-                },
-                {
-                    "include": "#modDocComment"
-                },
-                {
-                    "include": "#blockComment"
-                }
-            ]
-        }
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Aeon",
+  "scopeName": "source.aeon",
+  "fileTypes": [
+    ".ae"
+  ],
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#literals"
+    },
+    {
+      "include": "#operators"
+    },
+    {
+      "include": "#functions"
+    },
+    {
+      "include": "#types"
     }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "include": "#lineComment"
+        }
+      ]
+    },
+    "lineComment": {
+      "patterns": [
+        {
+          "name": "comment.line.number-sign.ae",
+          "match": "#.*$"
+        }
+      ],
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "name": "keyword.comment.todo.ae",
+              "match": "\\bTODO\\b"
+            }
+          ]
+        }
+      }
+    },
+    "literals": {
+      "patterns": [
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#numbers"
+        },
+        {
+          "include": "#booleans"
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.double.ae",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.ae",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.float.ae",
+          "match": "\\b\\d+\\.\\d+\\b"
+        },
+        {
+          "name": "constant.numeric.integer.ae",
+          "match": "\\b\\d+\\b"
+        }
+      ]
+    },
+    "booleans": {
+      "patterns": [
+        {
+          "name": "constant.language.boolean.ae",
+          "match": "\\b(true|false)\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.arithmetic.ae",
+          "match": "\\+|\\-|\\*|\\/|\\%"
+        },
+        {
+          "name": "keyword.operator.comparison.ae",
+          "match": "==|>=|<=|>|<|!="
+        },
+        {
+          "name": "keyword.operator.logical.ae",
+          "match": "\\|\\||&&|!"
+        },
+        {
+          "name": "keyword.operator.lambda.ae",
+          "match": "=>|\\->"
+        },
+        {
+          "name": "keyword.operator.assignment.ae",
+          "match": "="
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "include": "#primitiveTypes"
+        },
+        {
+          "include": "#liquidTypes"
+        }
+      ]
+    },
+    "primitiveTypes": {
+      "patterns": [
+        {
+          "name": "entity.name.type.ae",
+          "match": "\\b(Unit|Int|Float|String|Bool)\\b"
+        }
+      ]
+    },
+    "liquidTypes": {
+      "patterns": [
+        {
+          "name": "entity.name.type.liquidtype.ae",
+          "match": "\\{([^}]+)\\|([^}]+)\\}"
+        },
+        {
+          "name": "keyword.operator.liquidtype.ae",
+          "match": "\\|"
+        }
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {
+          "include": "#functionDefinitions"
+        },
+        {
+          "include": "#nativeFunctions"
+        }
+      ]
+    },
+    "functionDefinitions": {
+      "patterns": [
+        {
+          "name": "entity.name.function.ae",
+          "match": "\\b(def\\s+([a-zA-Z][a-zA-Z0-9]*))\\b"
+        },
+        {
+          "name": "variable.parameter.ae",
+          "match": "\\b([a-zA-Z][a-zA-Z0-9]*)\\s*:"
+        }
+      ]
+    },
+    "nativeFunctions": {
+      "patterns": [
+        {
+          "name": "support.function.ae",
+          "match": "\\b(native|native_import)\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "include": "#importKeywords"
+        },
+        {
+          "include": "#controlKeywords"
+        }
+      ]
+    },
+    "importKeywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.import.ae",
+          "match": "^(import)\\s+(.+)"
+        }
+      ]
+    },
+    "controlKeywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.ae",
+          "match": "\\b(if|then|else|let|def|@minimize|@maximize)\\b"
+        }
+      ]
+    }
+  }
 }

--- a/vscode-aeon/syntaxes/aeon.json
+++ b/vscode-aeon/syntaxes/aeon.json
@@ -191,8 +191,36 @@
     "nativeFunctions": {
       "patterns": [
         {
-          "name": "support.function.aeon",
-          "match": "\\b(native|native_import)\\b"
+          "name": "meta.embedded.python.aeon",
+          "begin": "(native)\\s+\"",
+          "end": "\"",
+          "captures": {
+            "1": {
+              "name": "support.function.native.aeon"
+            }
+          },
+          "contentName": "source.python",
+          "patterns": [
+            {
+              "include": "source.python"
+            }
+          ]
+        },
+        {
+          "name": "meta.native.import.aeon",
+          "begin": "(native_import)\\s+\"",
+          "end": "\"",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.import.native.aeon"
+            }
+          },
+          "contentName": "string.quoted.module.python",
+          "patterns": [
+            {
+              "include": "source.python"
+            }
+          ]
         }
       ]
     },
@@ -235,7 +263,7 @@
           "match": "\\b(if|then|else)\\b",
           "captures": {
             "1": {
-              "name": "keyword.control.aeon"
+              "name": "keyword.control.$1.aeon"
             }
           }
         }

--- a/vscode-aeon/syntaxes/aeon.json
+++ b/vscode-aeon/syntaxes/aeon.json
@@ -3,7 +3,7 @@
   "name": "Aeon",
   "scopeName": "source.aeon",
   "fileTypes": [
-    ".ae"
+    "ae"
   ],
   "patterns": [
     {
@@ -36,20 +36,10 @@
     "lineComment": {
       "patterns": [
         {
-          "name": "comment.line.number-sign.ae",
-          "match": "#.*$"
+          "match": "#.*$",
+          "name": "keyword.comment.todo.aeon"
         }
-      ],
-      "captures": {
-        "1": {
-          "patterns": [
-            {
-              "name": "keyword.comment.todo.ae",
-              "match": "\\bTODO\\b"
-            }
-          ]
-        }
-      }
+      ]
     },
     "literals": {
       "patterns": [
@@ -65,12 +55,12 @@
       ]
     },
     "strings": {
-      "name": "string.quoted.double.ae",
+      "name": "string.quoted.double.aeon",
       "begin": "\"",
       "end": "\"",
       "patterns": [
         {
-          "name": "constant.character.escape.ae",
+          "name": "constant.character.escape.aeon",
           "match": "\\\\."
         }
       ]
@@ -78,19 +68,22 @@
     "numbers": {
       "patterns": [
         {
-          "name": "constant.numeric.float.ae",
-          "match": "\\b\\d+\\.\\d+\\b"
-        },
-        {
-          "name": "constant.numeric.integer.ae",
-          "match": "\\b\\d+\\b"
+          "match": "\\b\\d+(\\.\\d+)?\\b",
+          "captures": {
+            "0": {
+              "name": "constant.numeric.integer.aeon"
+            },
+            "1": {
+              "name": "constant.numeric.float.aeon"
+            }
+          }
         }
       ]
     },
     "booleans": {
       "patterns": [
         {
-          "name": "constant.language.boolean.ae",
+          "name": "constant.language.boolean.aeon",
           "match": "\\b(true|false)\\b"
         }
       ]
@@ -98,23 +91,23 @@
     "operators": {
       "patterns": [
         {
-          "name": "keyword.operator.arithmetic.ae",
+          "name": "keyword.operator.arithmetic.aeon",
           "match": "\\+|\\-|\\*|\\/|\\%"
         },
         {
-          "name": "keyword.operator.comparison.ae",
+          "name": "keyword.operator.comparison.aeon",
           "match": "==|>=|<=|>|<|!="
         },
         {
-          "name": "keyword.operator.logical.ae",
+          "name": "keyword.operator.logical.aeon",
           "match": "\\|\\||&&|!"
         },
         {
-          "name": "keyword.operator.lambda.ae",
+          "name": "keyword.operator.lambda.aeon",
           "match": "=>|\\->"
         },
         {
-          "name": "keyword.operator.assignment.ae",
+          "name": "keyword.operator.assignment.aeon",
           "match": "="
         }
       ]
@@ -126,13 +119,27 @@
         },
         {
           "include": "#liquidTypes"
+        },
+        {
+          "include": "#typeAssignment"
         }
       ]
+    },
+    "typeAssignment": {
+      "match": "\\b[a-zA-Z][a-zA-Z0-9_]*\\s*(:)\\s*([a-zA-Z][a-zA-Z0-9_]*)\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.type.assignment.aeon"
+        },
+        "2": {
+          "name": "entity.name.type.aeon"
+        }
+      }
     },
     "primitiveTypes": {
       "patterns": [
         {
-          "name": "entity.name.type.ae",
+          "name": "entity.name.type.aeon",
           "match": "\\b(Unit|Int|Float|String|Bool)\\b"
         }
       ]
@@ -140,11 +147,11 @@
     "liquidTypes": {
       "patterns": [
         {
-          "name": "entity.name.type.liquidtype.ae",
+          "name": "entity.name.type.liquidtype.aeon",
           "match": "\\{([^}]+)\\|([^}]+)\\}"
         },
         {
-          "name": "keyword.operator.liquidtype.ae",
+          "name": "keyword.operator.liquidtype.aeon",
           "match": "\\|"
         }
       ]
@@ -162,19 +169,29 @@
     "functionDefinitions": {
       "patterns": [
         {
-          "name": "entity.name.function.ae",
-          "match": "\\b(def\\s+([a-zA-Z][a-zA-Z0-9]*))\\b"
-        },
-        {
-          "name": "variable.parameter.ae",
-          "match": "\\b([a-zA-Z][a-zA-Z0-9]*)\\s*:"
+          "match": "\\b(def)\\s+([a-zA-Z][a-zA-Z0-9_]*)(\\s*\\(.*\\)\\s*)*(:)\\s+([a-zA-Z][a-zA-Z0-9_]*)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.type.assignment.aeon"
+            },
+            "2": {
+              "name": "entity.name.type.aeon"
+            },
+            "3": {},
+            "4": {
+              "name": "keyword.operator.type.assignment.aeon"
+            },
+            "5": {
+              "name": "storage.type.aeon"
+            }
+          }
         }
       ]
     },
     "nativeFunctions": {
       "patterns": [
         {
-          "name": "support.function.ae",
+          "name": "support.function.aeon",
           "match": "\\b(native|native_import)\\b"
         }
       ]
@@ -182,26 +199,45 @@
     "keywords": {
       "patterns": [
         {
-          "include": "#importKeywords"
+          "include": "#importKeyword"
         },
         {
           "include": "#controlKeywords"
         }
       ]
     },
-    "importKeywords": {
+    "importKeyword": {
       "patterns": [
         {
-          "name": "keyword.control.import.ae",
-          "match": "^(import)\\s+(.+)"
+          "match": "^(import)\\s+\"(.+)\"",
+          "captures": {
+            "1": {
+              "name": "keyword.other.import.aeon"
+            },
+            "2": {
+              "name": "entity.name.namespace.aeon"
+            }
+          }
         }
       ]
     },
     "controlKeywords": {
       "patterns": [
         {
-          "name": "keyword.control.ae",
-          "match": "\\b(if|then|else|let|def|@minimize|@maximize)\\b"
+          "match": "\\b(where|let|in)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.other.$1.aeon"
+            }
+          }
+        },
+        {
+          "match": "\\b(if|then|else)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.aeon"
+            }
+          }
         }
       ]
     }

--- a/vscode-aeon/syntaxes/aeon.yaml
+++ b/vscode-aeon/syntaxes/aeon.yaml
@@ -86,15 +86,29 @@ repository:
           "5": { name: storage.type.aeon }
   nativeFunctions:
     patterns:
-      - name: support.function.aeon
-        match: \b(native|native_import)\b #TODO improve this in the future to support python native syntax highlighting
+      - name: meta.embedded.python.aeon
+        begin: '(native)\s+"'
+        end: '"'
+        captures:
+          "1": { name: support.function.native.aeon }
+        contentName: source.python
+        patterns:
+          - include: source.python
+      - name: meta.native.import.aeon 
+        begin: '(native_import)\s+"'
+        end: '"'
+        beginCaptures:
+          "1": { name: keyword.control.import.native.aeon }
+        contentName: string.quoted.module.python
+        patterns:
+          - include: source.python
   keywords:
     patterns:
       - include: "#importKeyword"
       - include: "#controlKeywords"
   importKeyword:
     patterns:
-      - match: '^(import)\s+"(.+)"' #adiciar entity.name.namespace.aeon
+      - match: '^(import)\s+"(.+)"'
         captures:
           "1": { name: keyword.other.import.aeon }
           "2": { name: entity.name.namespace.aeon }
@@ -106,4 +120,4 @@ repository:
 
       - match: '\b(if|then|else)\b'
         captures:
-          "1": { name: keyword.control.aeon }
+          "1": { name: keyword.control.$1.aeon }

--- a/vscode-aeon/syntaxes/aeon.yaml
+++ b/vscode-aeon/syntaxes/aeon.yaml
@@ -1,98 +1,109 @@
 $schema: https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json
 name: Aeon
 scopeName: source.aeon
-fileTypes: [.ae]
+fileTypes: [ae]
 patterns:
-  - include: '#comments'
-  - include: '#keywords'
-  - include: '#literals'
-  - include: '#operators'
-  - include: '#functions'
-  - include: '#types'
+  - include: "#comments"
+  - include: "#keywords"
+  - include: "#literals"
+  - include: "#operators"
+  - include: "#functions"
+  - include: "#types"
 repository:
   comments:
     patterns:
-      - include: '#lineComment'
+      - include: "#lineComment"
   lineComment:
     patterns:
-      - name: comment.line.number-sign.ae
-        match: '#.*$'
-    captures:
-      '1':
-        patterns:
-          - name: keyword.comment.todo.ae
-            match: \bTODO\b
+      - match: "#.*$"
+        name: keyword.comment.todo.aeon
   literals:
     patterns:
-      - include: '#strings'
-      - include: '#numbers'
-      - include: '#booleans'
+      - include: "#strings"
+      - include: "#numbers"
+      - include: "#booleans"
   strings:
-    name: string.quoted.double.ae
+    name: string.quoted.double.aeon
     begin: '"'
     end: '"'
     patterns:
-      - name: constant.character.escape.ae
+      - name: constant.character.escape.aeon
         match: \\.
   numbers:
     patterns:
-      - name: constant.numeric.float.ae
-        match: \b\d+\.\d+\b
-      - name: constant.numeric.integer.ae
-        match: \b\d+\b
+      - match: '\b\d+(\.\d+)?\b'
+        captures:
+          "0": { name: constant.numeric.integer.aeon }
+          "1": { name: constant.numeric.float.aeon }
   booleans:
     patterns:
-      - name: constant.language.boolean.ae
+      - name: constant.language.boolean.aeon
         match: \b(true|false)\b
   operators:
     patterns:
-      - name: keyword.operator.arithmetic.ae
+      - name: keyword.operator.arithmetic.aeon
         match: \+|\-|\*|\/|\%
-      - name: keyword.operator.comparison.ae
-        match: '==|>=|<=|>|<|!='
-      - name: keyword.operator.logical.ae
+      - name: keyword.operator.comparison.aeon
+        match: "==|>=|<=|>|<|!="
+      - name: keyword.operator.logical.aeon
         match: \|\||&&|!
-      - name: keyword.operator.lambda.ae
+      - name: keyword.operator.lambda.aeon
         match: '=>|\->'
-      - name: keyword.operator.assignment.ae
-        match: '='
+      - name: keyword.operator.assignment.aeon
+        match: "="
   types:
     patterns:
-      - include: '#primitiveTypes'
-      - include: '#liquidTypes'
+      - include: "#primitiveTypes"
+      - include: "#liquidTypes"
+      - include: "#typeAssignment"
+  typeAssignment:
+    match: '\b[a-zA-Z][a-zA-Z0-9_]*\s*(:)\s*([a-zA-Z][a-zA-Z0-9_]*)\b'
+    captures:
+      "1": { name: keyword.operator.type.assignment.aeon }
+      "2": { name: entity.name.type.aeon }
   primitiveTypes:
     patterns:
-      - name: entity.name.type.ae
+      - name: entity.name.type.aeon
         match: \b(Unit|Int|Float|String|Bool)\b
   liquidTypes:
     patterns:
-      - name: entity.name.type.liquidtype.ae
+      - name: entity.name.type.liquidtype.aeon
         match: \{([^}]+)\|([^}]+)\}
-      - name: keyword.operator.liquidtype.ae
+      - name: keyword.operator.liquidtype.aeon
         match: \|
   functions:
     patterns:
-      - include: '#functionDefinitions'
-      - include: '#nativeFunctions'
+      - include: "#functionDefinitions"
+      - include: "#nativeFunctions"
   functionDefinitions:
     patterns:
-      - name: entity.name.function.ae
-        match: \b(def\s+([a-zA-Z][a-zA-Z0-9]*))\b
-      - name: variable.parameter.ae
-        match: '\b([a-zA-Z][a-zA-Z0-9]*)\s*:'
+      - match: '\b(def)\s+([a-zA-Z][a-zA-Z0-9_]*)(\s*\(.*\)\s*)*(:)\s+([a-zA-Z][a-zA-Z0-9_]*)\b'
+        captures:
+          "1": { name: keyword.operator.type.assignment.aeon }
+          "2": { name: entity.name.type.aeon }
+          "3": {} #TODO needs to be further processed
+          "4": { name: keyword.operator.type.assignment.aeon}
+          "5": { name: storage.type.aeon }
   nativeFunctions:
     patterns:
-      - name: support.function.ae
-        match: \b(native|native_import)\b
+      - name: support.function.aeon
+        match: \b(native|native_import)\b #TODO improve this in the future to support python native syntax highlighting
   keywords:
     patterns:
-      - include: '#importKeywords'
-      - include: '#controlKeywords'
-  importKeywords:
+      - include: "#importKeyword"
+      - include: "#controlKeywords"
+  importKeyword:
     patterns:
-      - name: keyword.control.import.ae
-        match: ^(import)\s+(.+)
+      - match: '^(import)\s+"(.+)"' #adiciar entity.name.namespace.aeon
+        captures:
+          "1": { name: keyword.other.import.aeon }
+          "2": { name: entity.name.namespace.aeon }
   controlKeywords:
     patterns:
-      - name: keyword.control.ae
-        match: \b(if|then|else|let|def|@minimize|@maximize)\b
+      - match: '\b(where|let|in)\b'
+        captures:
+          "1": { name: keyword.other.$1.aeon }
+
+      - match: '\b(if|then|else)\b'
+        captures:
+          "1": { name: keyword.control.aeon }

--- a/vscode-aeon/syntaxes/aeon.yaml
+++ b/vscode-aeon/syntaxes/aeon.yaml
@@ -1,0 +1,98 @@
+$schema: https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json
+name: Aeon
+scopeName: source.aeon
+fileTypes: [.ae]
+patterns:
+  - include: '#comments'
+  - include: '#keywords'
+  - include: '#literals'
+  - include: '#operators'
+  - include: '#functions'
+  - include: '#types'
+repository:
+  comments:
+    patterns:
+      - include: '#lineComment'
+  lineComment:
+    patterns:
+      - name: comment.line.number-sign.ae
+        match: '#.*$'
+    captures:
+      '1':
+        patterns:
+          - name: keyword.comment.todo.ae
+            match: \bTODO\b
+  literals:
+    patterns:
+      - include: '#strings'
+      - include: '#numbers'
+      - include: '#booleans'
+  strings:
+    name: string.quoted.double.ae
+    begin: '"'
+    end: '"'
+    patterns:
+      - name: constant.character.escape.ae
+        match: \\.
+  numbers:
+    patterns:
+      - name: constant.numeric.float.ae
+        match: \b\d+\.\d+\b
+      - name: constant.numeric.integer.ae
+        match: \b\d+\b
+  booleans:
+    patterns:
+      - name: constant.language.boolean.ae
+        match: \b(true|false)\b
+  operators:
+    patterns:
+      - name: keyword.operator.arithmetic.ae
+        match: \+|\-|\*|\/|\%
+      - name: keyword.operator.comparison.ae
+        match: '==|>=|<=|>|<|!='
+      - name: keyword.operator.logical.ae
+        match: \|\||&&|!
+      - name: keyword.operator.lambda.ae
+        match: '=>|\->'
+      - name: keyword.operator.assignment.ae
+        match: '='
+  types:
+    patterns:
+      - include: '#primitiveTypes'
+      - include: '#liquidTypes'
+  primitiveTypes:
+    patterns:
+      - name: entity.name.type.ae
+        match: \b(Unit|Int|Float|String|Bool)\b
+  liquidTypes:
+    patterns:
+      - name: entity.name.type.liquidtype.ae
+        match: \{([^}]+)\|([^}]+)\}
+      - name: keyword.operator.liquidtype.ae
+        match: \|
+  functions:
+    patterns:
+      - include: '#functionDefinitions'
+      - include: '#nativeFunctions'
+  functionDefinitions:
+    patterns:
+      - name: entity.name.function.ae
+        match: \b(def\s+([a-zA-Z][a-zA-Z0-9]*))\b
+      - name: variable.parameter.ae
+        match: '\b([a-zA-Z][a-zA-Z0-9]*)\s*:'
+  nativeFunctions:
+    patterns:
+      - name: support.function.ae
+        match: \b(native|native_import)\b
+  keywords:
+    patterns:
+      - include: '#importKeywords'
+      - include: '#controlKeywords'
+  importKeywords:
+    patterns:
+      - name: keyword.control.import.ae
+        match: ^(import)\s+(.+)
+  controlKeywords:
+    patterns:
+      - name: keyword.control.ae
+        match: \b(if|then|else|let|def|@minimize|@maximize)\b


### PR DESCRIPTION
### Still Unsupported:
    - Arguments and return types being highlighted in a function declaration
    - Macros for constraints
    - Kinds
    - Syntax highlighting for native imports (python syntax highlighting)
    - Some literals