### PR TITLE
Add aeon.localPackagePath setting to use a local aeon package

### DIFF
--- a/vscode-aeon/package.json
+++ b/vscode-aeon/package.json
@@ -33,6 +33,11 @@
           "type": "boolean",
           "default": false,
           "description": "If true, uses the system-wide Aeon interpreter instead of the local virtual environment."
+        },
+        "aeon.localPackagePath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to a local aeon Python package folder to use instead of the published PyPI package. When set, the language server is launched with 'uvx --from <path>' instead of 'uvx --from aeonlang'."
         }
       }
     },

--- a/vscode-aeon/src/aeonClient.ts
+++ b/vscode-aeon/src/aeonClient.ts
@@ -4,6 +4,7 @@ import { Executable, LanguageClient, Middleware } from 'vscode-languageclient/no
 import { AeonInstallationHandler, PreConditionResult } from './handlers/aeonInstallationHandler'
 import { DiagnosticsHandler } from './handlers/diagnosticsHandler'
 import { NotificationHandler } from './handlers/notificationHandler'
+import { localPackagePath } from './config'
 
 export class AeonClient implements Disposable {
     private client: LanguageClient
@@ -43,6 +44,13 @@ export class AeonClient implements Disposable {
     }
 
     private getServerExecutable(aeonInstallationHandler: AeonInstallationHandler) {
+        const pkgPath = localPackagePath()
+        if (pkgPath) {
+            return {
+                command: "uvx",
+                args: ['--from', pkgPath, 'aeon', '--language-server-mode'],
+            }
+        }
         return {
             command: "uvx",
             args: ['--from', 'aeonlang', 'aeon', '--language-server-mode'],

--- a/vscode-aeon/src/config.ts
+++ b/vscode-aeon/src/config.ts
@@ -17,3 +17,8 @@ export function useSystemInterpreter(): boolean {
 
     return useSystemInterpreter === true
 }
+
+export function localPackagePath(): string {
+    const p: string | undefined = vscode.workspace.getConfiguration('aeon').get('localPackagePath')
+    return p?.trim() ?? ''
+}


### PR DESCRIPTION
## Summary
- Adds a new `aeon.localPackagePath` setting (string, default empty)
- When set to a local folder path, the language server is launched with `uvx --from <path> aeon --language-server-mode` instead of `uvx --from aeonlang aeon --language-server-mode`
- Useful for developing against a local checkout of the aeon Python package without publishing to PyPI

## Usage
Set in `.vscode/settings.json`:
```json
{
  "aeon.localPackagePath": "/path/to/aeon"
}
```

## Test plan
- [ ] Leave setting empty → server starts from PyPI (`uvx --from aeonlang`)
- [ ] Set to a local aeon folder → server starts from that folder (`uvx --from /path/to/aeon`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)