### PR TITLE
Lean-style operators: := for definitions, = for equality

### DIFF
--- a/vscode-aeon/media/guide-documentation.md
+++ b/vscode-aeon/media/guide-documentation.md
@@ -23,7 +23,7 @@ The documentation is available at [https://alcides.github.io/aeon](https://alcid
 In this example, you can see the refined type `{x:Int | x > 0}` that represents all integers that are greater than 0. You can also see an example of Python FFI, where a python valid expression can be written as string and passed as the argument to the `native` function.
 
 ```
-def sqrt : (i: {x:Int | x > 0} ) -> Float = native "__import__('math').sqrt";
+def sqrt : (i: {x:Int | x > 0} ) -> Float := native "__import__('math').sqrt";
 
 def main (i:Int) : Unit {
     print (sqrt (-25)) # This is a type-checking error!

--- a/vscode-aeon/package.json
+++ b/vscode-aeon/package.json
@@ -2,7 +2,7 @@
   "name": "aeon-lang",
   "displayName": "Æon Language",
   "description": "Aeon language support for VS Code",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "publisher": "AlcidesFonseca",
   "engines": {
     "vscode": "^1.75.0"

--- a/vscode-aeon/syntaxes/aeon.json
+++ b/vscode-aeon/syntaxes/aeon.json
@@ -289,7 +289,7 @@
         },
         {
           "name": "keyword.operator.assignment.aeon",
-          "match": "="
+          "match": ":="
         },
         {
           "name": "punctuation.separator.type",
@@ -301,7 +301,7 @@
         },
         {
           "name": "keyword.operator.comparison.aeon",
-          "match": "(==|>=|<=|!=|>|<|-->)"
+          "match": "(==|>=|<=|!=|>|<|-->|=)"
         },
         {
           "name": "keyword.operator.arithmetic.integer.aeon",

--- a/vscode-aeon/syntaxes/aeon.yaml
+++ b/vscode-aeon/syntaxes/aeon.yaml
@@ -139,13 +139,13 @@ repository:
       - name: keyword.operator.lambda.kind.arrow.aeon
         match: '=>'
       - name: keyword.operator.assignment.aeon
-        match: '='
+        match: ':='
       - name: punctuation.separator.type
         match: ':'
       - name: keyword.operator.logical.aeon
         match: (\|\||&&|!)
       - name: keyword.operator.comparison.aeon
-        match: (==|>=|<=|!=|>|<|-->)
+        match: (==|>=|<=|!=|>|<|-->|=)
       - name: keyword.operator.arithmetic.integer.aeon
         match: (\+|-|\*|/|%)
       - name: keyword.operator.arithmetic.float.aeon


### PR DESCRIPTION
## What

Make Aeon's syntax closer to Lean: `=` highlights as **equality** and `:=` as **definition/binding**.

## Changes

- **Grammar** (`vscode-aeon/syntaxes/aeon.json`, the active grammar referenced by `package.json`, plus its hand-authored YAML source `aeon.yaml`):
  - The assignment/definition operator changes from `=` to `:=` (`keyword.operator.assignment.aeon`).
  - Bare `=` is added to the comparison group (`==|>=|<=|!=|>|<|-->|=`) so it now highlights as equality. `==` and the kind arrow `=>` are still matched first, so a lone `=` only ever lands on genuine equality.
- **Docs** (`vscode-aeon/media/guide-documentation.md`): the `sqrt` example now uses `:=` for the definition.

## Notes for reviewers

- There are no `.ae` source files in the repo; the only Aeon code lived in the doc example, which is updated.
- `aeon.json` is generated from `aeon.yaml` by hand (no build step), so both were kept in sync. The JSON parses cleanly.
- This is the **syntax-highlighting grammar only**. If the separate Aeon parser/interpreter still expects `=` for definitions, the same change should be made there so highlighting and parsing agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)