### PR TITLE
chore(dev): add one-shot F5 launch config for the Info View extension

### DIFF
--- a/vscode-aeon/.vscode/launch.json
+++ b/vscode-aeon/.vscode/launch.json
@@ -6,6 +6,23 @@
     "version": "0.2.0",
     "configurations": [
         {
+            // Compiles once (clean exit) then opens the Extension Development
+            // Host with the Aeon extension — including the Info View — loaded.
+            // Press F5 to use this. Point the server at a local checkout with
+            // the "aeon.localPackagePath" setting in the dev-host window.
+            "name": "Run Aeon Info View Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
+            "preLaunchTask": "npm: compile"
+        },
+        {
             "name": "Run Extension",
             "type": "extensionHost",
             "request": "launch",

--- a/vscode-aeon/.vscode/tasks.json
+++ b/vscode-aeon/.vscode/tasks.json
@@ -4,6 +4,17 @@
     "version": "2.0.0",
     "tasks": [
         {
+            // One-shot esbuild bundle; exits cleanly so F5's preLaunchTask
+            // does not hang waiting on a background watcher.
+            "type": "npm",
+            "script": "compile",
+            "problemMatcher": [],
+            "presentation": {
+                "reveal": "silent"
+            },
+            "group": "build"
+        },
+        {
             "type": "npm",
             "script": "watch",
             "problemMatcher": "$tsc-watch",


### PR DESCRIPTION
## Summary
- Adds a **Run Aeon Info View Extension** launch configuration as the new F5 default, which compiles once and opens the Extension Development Host.
- Adds a one-shot `npm: compile` task (clean exit, no problem matcher) so the `preLaunchTask` does not hang.
- Leaves the existing watch-based `Run Extension` config and `npm: watch` task in place as a secondary option.

## Why
The existing watch-based config used a `$tsc-watch` problem matcher against an esbuild build, whose output never matches the matcher's end pattern, so F5 could hang on the background prelaunch task.

## Test plan
- [ ] Open the repo in VS Code, press F5, and verify the Extension Development Host opens without hanging.
- [ ] Confirm the Aeon Info View loads in the dev-host window (point at a local server via `aeon.localPackagePath` if needed).
- [ ] Confirm the legacy "Run Extension" + `npm: watch` config still works for iterative development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)