### PR TITLE
Bump engines.vscode to ^1.116.0 to match @types/vscode

### DIFF
--- a/vscode-aeon/package.json
+++ b/vscode-aeon/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.16",
   "publisher": "AlcidesFonseca",
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.116.0"
   },
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary

After merging #186 (`@types/vscode` → `^1.116.0`), `main`'s build broke: `vsce package` rejects `@types/vscode ^1.116.0` when `engines.vscode` is `^1.75.0`.

This bumps `engines.vscode` to `^1.116.0` to match, restoring a green build. Verified locally — `npm ci && npm run build && npm run package` now succeeds.

This also unblocks #187 and #189, which fail CI on the same `vsce package` step purely because of this `main` breakage.

https://claude.ai/code/session_018ujP8KDBiS7X3tMr5TDieZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018ujP8KDBiS7X3tMr5TDieZ)_