### PR TITLE
Release 0.0.17

### DIFF
--- a/vscode-aeon/package.json
+++ b/vscode-aeon/package.json
@@ -2,7 +2,7 @@
   "name": "aeon-lang",
   "displayName": "Æon Language",
   "description": "Aeon language support for VS Code",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publisher": "AlcidesFonseca",
   "engines": {
     "vscode": "^1.116.0"


### PR DESCRIPTION
## Summary

Bumps the extension version to **0.0.17** for the next release.

Since the last release (v0.0.16), main has gained:
- **#185** — synthesizer sync with the aeon backend (`aeon.defaultSynthesizer` config, hover docs, README overhaul; synthesizer list aligned with aeon master's LSP — 12 backends)
- **#209** — `engines.vscode` bumped to `^1.116.0` to match `@types/vscode` (fixes `vsce package`)
- Dependency bumps: axios, tmp, qs, fast-uri, ip-address, uuid/@azure/identity/lerna, @stylistic/eslint-plugin, @types/vscode, follow-redirects, lodash, handlebars

Once merged, I'll push the `v0.0.17` tag, which triggers the publish workflow (VS Code Marketplace + Open VSX + GitHub release).

https://claude.ai/code/session_018ujP8KDBiS7X3tMr5TDieZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018ujP8KDBiS7X3tMr5TDieZ)_