### PR TITLE
feat(infoview): three-tab info view (Errors, Context, Synthesis)

### DIFF
--- a/vscode-aeon/src/aeonClient.ts
+++ b/vscode-aeon/src/aeonClient.ts
@@ -4,7 +4,7 @@ import { Executable, LanguageClient, Middleware } from 'vscode-languageclient/no
 import { AeonInstallationHandler, PreConditionResult } from './handlers/aeonInstallationHandler'
 import { DiagnosticsHandler } from './handlers/diagnosticsHandler'
 import { NotificationHandler } from './handlers/notificationHandler'
-import { localPackagePath, defaultSynthesizer } from './config'
+import { aeonExecutable, defaultSynthesizer } from './config'
 
 export class AeonClient implements Disposable {
     private client: LanguageClient
@@ -23,7 +23,7 @@ export class AeonClient implements Disposable {
         this.outputChannel = aeonInstallationHandler.getOutputChannel()
         this.notificationHandler = aeonInstallationHandler.getNotificationHandler()
 
-        const serverExecutable: Executable = this.getServerExecutable(aeonInstallationHandler)
+        const serverExecutable: Executable = this.getServerExecutable()
         const clientOptions: LanguageClientOptions = this.getClientOptions()
         this.client = new LanguageClient('aeon', 'Aeon', serverExecutable, clientOptions)
     }
@@ -34,6 +34,8 @@ export class AeonClient implements Disposable {
                 this.diagnosticsHandler.updateDiagnostics(uri, diagnostics)
                 next(uri, diagnostics)
             },
+            // Suppress the server's inferred-type inlay hints (rendered in grey) from the editor.
+            provideInlayHints: () => [],
             provideCodeActions: async (document, range, context, token, next) => {
                 const actions = await next(document, range, context, token)
                 if (!Array.isArray(actions)) return actions
@@ -55,18 +57,8 @@ export class AeonClient implements Disposable {
         }
     }
 
-    private getServerExecutable(aeonInstallationHandler: AeonInstallationHandler) {
-        const pkgPath = localPackagePath()
-        if (pkgPath) {
-            return {
-                command: "uvx",
-                args: ['--from', pkgPath, 'aeon', '--language-server-mode'],
-            }
-        }
-        return {
-            command: "uvx",
-            args: ['--refresh', '--from', 'aeonlang', 'aeon', '--language-server-mode'],
-        }
+    private getServerExecutable() {
+        return aeonExecutable(['--language-server-mode'])
     }
 
     /** Send a custom request (e.g. `aeon/infoView`) to the language server. */
@@ -80,6 +72,19 @@ export class AeonClient implements Disposable {
     /** Subscribe to a server-pushed notification (e.g. `aeon/synthesisProgress`). */
     onNotification(method: string, handler: (params: unknown) => void): Disposable {
 	return this.client.onNotification(method, handler)
+    }
+
+    /** Run a server-side command (e.g. `aeon.synthesize`) via
+     * `workspace/executeCommand`. Server commands are not registered as VS Code
+     * commands, so they must be dispatched through the LSP client. */
+    async executeCommand(command: string, args: unknown[]): Promise<void> {
+	if (!this.running) {
+	    throw new Error('Aeon language server is not running')
+	}
+	await this.client.sendRequest('workspace/executeCommand', {
+	    command,
+	    arguments: args,
+	})
     }
 
     async restart(): Promise<void> {

--- a/vscode-aeon/src/config.ts
+++ b/vscode-aeon/src/config.ts
@@ -27,3 +27,16 @@ export function defaultSynthesizer(): string {
     const s: string | undefined = vscode.workspace.getConfiguration('aeon').get('defaultSynthesizer')
     return s?.trim() || 'gp'
 }
+
+/**
+ * Build the command + args used to invoke the `aeon` program (via `uvx`),
+ * honouring the `aeon.localPackagePath` setting. `extraArgs` are appended after
+ * the `aeon` subcommand, e.g. `['--language-server-mode']` or `['--format', file]`.
+ */
+export function aeonExecutable(extraArgs: string[]): { command: string; args: string[] } {
+    const pkgPath = localPackagePath()
+    if (pkgPath) {
+        return { command: 'uvx', args: ['--from', pkgPath, 'aeon', ...extraArgs] }
+    }
+    return { command: 'uvx', args: ['--refresh', '--from', 'aeonlang', 'aeon', ...extraArgs] }
+}

--- a/vscode-aeon/src/infoview/infoViewProvider.ts
+++ b/vscode-aeon/src/infoview/infoViewProvider.ts
@@ -13,10 +13,39 @@ interface InfoEntry {
     predicate: string | null
 }
 
+/** One step of a failing VC's simplification chain (see
+ * `aeon.verification.helpers.vc_simplification_steps`). Ordered original →
+ * simplified; each `label` describes how its `text` was produced. */
+interface VCStep {
+    label: string
+    text: string
+}
+
+/** A diagnostic for the error tab. Liquid type-checking failures carry a
+ * `counterexample` and the `vcSteps` chain of the failing VC. */
+interface ErrorInfo {
+    message: string
+    severity: string
+    counterexample: string | null
+    vcSteps: VCStep[]
+    line: number | null
+    endLine: number | null
+    atCursor: boolean
+}
+
+/** A synthesis backend offered for the hole under the cursor. */
+interface SynthesizerInfo {
+    id: string
+    label: string
+}
+
 interface InfoViewResponse {
     target: { type: string; predicate: string | null } | null
     locals: InfoEntry[]
     globals: InfoEntry[]
+    errors: ErrorInfo[]
+    hole: string | null
+    synthesizers: SynthesizerInfo[]
 }
 
 /** Wire format of the `aeon/synthesisProgress` notification the server streams
@@ -34,15 +63,20 @@ interface SynthesisProgress {
 }
 
 const INFOVIEW_REQUEST = 'aeon/infoView'
+const SYNTHESIZE_COMMAND = 'aeon.synthesize'
 const DEBOUNCE_MS = 150
 /** Keep a finished synthesis result visible this long before clearing it. */
 const SYNTHESIS_CLEAR_MS = 12000
 
 /**
- * A Lean-style info view: a webview panel beside the editor showing, for the
- * current cursor position, the goal of the hole under the cursor, the type of
- * the expression under the cursor, the typing context (locals prominently,
- * globals collapsed) and the diagnostics at the cursor.
+ * A Lean-style info view: a webview panel beside the editor with three tabs for
+ * the current cursor position:
+ *   1. Error Messages — counterexamples and an interactive, expandable view of
+ *      the failing VC's simplification chain.
+ *   2. Context — the typing context (locals + goal + globals) laid out
+ *      left-aligned with refinements aligned in a column.
+ *   3. Synthesis — when the cursor is on a `?hole`, the available synthesis
+ *      algorithms (click to run) and live progress of a running search.
  */
 export class InfoViewProvider implements vscode.Disposable {
     private panel: vscode.WebviewPanel | undefined
@@ -51,6 +85,10 @@ export class InfoViewProvider implements vscode.Disposable {
     private requestSeq = 0
     private synthesis: SynthesisProgress | undefined
     private synthesisClearTimer: ReturnType<typeof setTimeout> | undefined
+    /** The document + hole the panel currently reflects, so a "run synthesis"
+     * click from the webview can target the right file and hole. */
+    private currentUri: string | undefined
+    private currentHole: string | null = null
 
     constructor(private readonly aeonClient: AeonClient) {
 	vscode.window.onDidChangeTextEditorSelection(
@@ -101,9 +139,27 @@ export class InfoViewProvider implements vscode.Disposable {
 	this.panel.onDidDispose(() => {
 	    this.panel = undefined
 	})
+	this.panel.webview.onDidReceiveMessage(
+	    msg => this.onWebviewMessage(msg),
+	    this,
+	    this.disposables,
+	)
 	this.panel.webview.html = this.shellHtml()
 	const editor = vscode.window.activeTextEditor
 	if (editor) this.scheduleUpdate(editor)
+    }
+
+    /** Messages posted by the webview script — currently the "run synthesis"
+     * buttons in the synthesis tab. */
+    private onWebviewMessage(msg: unknown): void {
+	const m = msg as { type?: string; synthesizer?: string } | null
+	if (!m || m.type !== 'synthesize' || typeof m.synthesizer !== 'string') return
+	if (!this.currentUri || !this.currentHole) return
+	void this.aeonClient.executeCommand(SYNTHESIZE_COMMAND, [
+	    this.currentUri,
+	    this.currentHole,
+	    m.synthesizer,
+	])
     }
 
     private scheduleUpdate(editor: vscode.TextEditor): void {
@@ -131,13 +187,30 @@ export class InfoViewProvider implements vscode.Disposable {
 	// A newer cursor position superseded this request while it was in flight.
 	if (seq !== this.requestSeq || !this.panel) return
 
-	const html = this.render(document, position, info)
-	void this.panel.webview.postMessage({ kind: 'update', html })
+	this.currentUri = document.uri.toString()
+	this.currentHole = info?.hole ?? null
+
+	const fileName = document.uri.path.split('/').pop() ?? document.uri.path
+	const location = `${esc(fileName)}:${position.line + 1}:${position.character + 1}`
+
+	// Prefer the server's structured errors; fall back to the diagnostics
+	// VS Code already holds (e.g. syntax errors) for both content and badge.
+	const serverErrorCount = info?.errors?.length ?? 0
+	const errorCount = serverErrorCount > 0 ? serverErrorCount : diagnosticsAt(document, position).length
+
+	void this.panel.webview.postMessage({
+	    kind: 'update',
+	    location,
+	    errors: this.renderErrors(document, position, info),
+	    errorCount,
+	    context: this.renderContext(info),
+	    synthesis: this.renderSynthesis(info),
+	})
     }
 
-    /** Handle an `aeon/synthesisProgress` notification: update the dedicated
-     * synthesis region of the info view (independent of the cursor-driven
-     * content), opening the panel if needed so progress is visible. */
+    /** Handle an `aeon/synthesisProgress` notification: update the live progress
+     * region of the synthesis tab (independent of the cursor-driven content),
+     * opening the panel and focusing the tab so progress is visible. */
     showSynthesisProgress(params: unknown): void {
 	const p = params as Partial<SynthesisProgress> | null
 	if (!p || typeof p.algorithm !== 'string') return
@@ -167,45 +240,54 @@ export class InfoViewProvider implements vscode.Disposable {
 	    clearTimeout(this.synthesisClearTimer)
 	    this.synthesisClearTimer = undefined
 	}
-	const html = this.synthesis ? synthesisHtml(this.synthesis) : ''
-	void this.panel?.webview.postMessage({ kind: 'synthesis', html })
+	const running = this.synthesis !== undefined && !this.synthesis.done
+	const html = this.synthesis ? synthesisProgressHtml(this.synthesis) : ''
+	void this.panel?.webview.postMessage({ kind: 'synthesisProgress', html, running, focus: true })
 	// Once finished, keep the result up briefly, then clear it.
 	if (this.synthesis?.done) {
 	    this.synthesisClearTimer = setTimeout(() => {
 		this.synthesis = undefined
-		void this.panel?.webview.postMessage({ kind: 'synthesis', html: '' })
+		void this.panel?.webview.postMessage({
+		    kind: 'synthesisProgress',
+		    html: '',
+		    running: false,
+		    focus: false,
+		})
 	    }, SYNTHESIS_CLEAR_MS)
 	}
     }
 
-    // ----------------------------------------------------------------- HTML
+    // ------------------------------------------------------------- tab: errors
 
-    private render(
+    private renderErrors(
 	document: vscode.TextDocument,
 	position: vscode.Position,
 	info: InfoViewResponse | null,
     ): string {
-	const fileName = document.uri.path.split('/').pop() ?? document.uri.path
-	const parts: string[] = []
-	parts.push(
-	    `<div class="location">${esc(fileName)}:${position.line + 1}:${position.character + 1}</div>`,
-	)
+	const errors = info?.errors ?? []
+	if (errors.length > 0) {
+	    return errors.map(errorHtml).join('')
+	}
+	// Fallback for errors the server does not surface structurally (e.g.
+	// syntax errors): the diagnostics VS Code already holds at the cursor.
+	const messages = diagnosticsAt(document, position)
+	if (messages.length > 0) {
+	    return messages.map(diagnosticHtml).join('')
+	}
+	return '<div class="empty">No errors at the cursor.</div>'
+    }
 
-	// Lean-style order: the local context first, then the goal turnstile.
+    // ------------------------------------------------------------ tab: context
+
+    private renderContext(info: InfoViewResponse | null): string {
+	const parts: string[] = []
 	const locals = info?.locals ?? []
 	if (locals.length > 0) {
-	    parts.push(section('Context', bindingTable(locals)))
+	    parts.push(section('Local Context', bindingTable(locals)))
 	}
-
 	if (info?.target) {
 	    parts.push(section('Goal', turnstileHtml(info.target)))
 	}
-
-	const messages = diagnosticsAt(document, position)
-	if (messages.length > 0) {
-	    parts.push(section('Messages', messages.map(diagnosticHtml).join('')))
-	}
-
 	const globals = info?.globals ?? []
 	if (globals.length > 0) {
 	    parts.push(
@@ -214,12 +296,32 @@ export class InfoViewProvider implements vscode.Disposable {
 		    '</details>',
 	    )
 	}
-
-	if (!info || (!info.target && locals.length === 0 && messages.length === 0)) {
-	    parts.push('<div class="empty">No information available at the cursor.</div>')
+	if (parts.length === 0) {
+	    parts.push('<div class="empty">No context available at the cursor.</div>')
 	}
 	return parts.join('\n')
     }
+
+    // ---------------------------------------------------------- tab: synthesis
+
+    private renderSynthesis(info: InfoViewResponse | null): string {
+	const hole = info?.hole ?? null
+	const synthesizers = info?.synthesizers ?? []
+	if (!hole) {
+	    return '<div class="empty">Place the cursor on a <code>?hole</code> to synthesize it.</div>'
+	}
+	const header = `<div class="syn-header">Synthesize <span class="hole">?${esc(hole)}</span> with:</div>`
+	const list = synthesizers
+	    .map(
+		s =>
+		    `<button class="syn-run" data-synth="${esc(s.id)}" title="${esc(s.id)}">` +
+		    `<span class="syn-run-icon">▶</span> ${esc(s.label)}</button>`,
+	    )
+	    .join('')
+	return `${header}<div class="syn-list">${list}</div>`
+    }
+
+    // ----------------------------------------------------------------- shell
 
     private shellHtml(): string {
 	return `<!DOCTYPE html>
@@ -232,13 +334,58 @@ export class InfoViewProvider implements vscode.Disposable {
 	font-family: var(--vscode-editor-font-family, monospace);
 	font-size: var(--vscode-editor-font-size, 13px);
 	color: var(--vscode-editor-foreground);
-	padding: 0.5em 0.8em;
+	padding: 0;
+	margin: 0;
     }
     .location {
 	color: var(--vscode-descriptionForeground);
 	font-size: 0.85em;
-	margin-bottom: 0.6em;
+	padding: 0.4em 0.8em 0;
     }
+    /* --- tab bar ---------------------------------------------------------- */
+    .tabs {
+	display: flex;
+	gap: 0.2em;
+	padding: 0.4em 0.6em 0;
+	border-bottom: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.35));
+	position: sticky;
+	top: 0;
+	background: var(--vscode-editor-background);
+	z-index: 1;
+    }
+    .tab {
+	font-family: var(--vscode-font-family, sans-serif);
+	font-size: 0.85em;
+	background: none;
+	border: none;
+	border-bottom: 2px solid transparent;
+	color: var(--vscode-descriptionForeground);
+	padding: 0.4em 0.7em;
+	cursor: pointer;
+	white-space: nowrap;
+    }
+    .tab:hover { color: var(--vscode-editor-foreground); }
+    .tab.active {
+	color: var(--vscode-editor-foreground);
+	border-bottom-color: var(--vscode-textLink-activeForeground, var(--vscode-focusBorder));
+    }
+    .tab .badge {
+	display: inline-block;
+	min-width: 1.4em;
+	text-align: center;
+	border-radius: 8px;
+	padding: 0 0.35em;
+	margin-left: 0.35em;
+	font-size: 0.85em;
+	background: var(--vscode-badge-background, rgba(128,128,128,0.3));
+	color: var(--vscode-badge-foreground, inherit);
+    }
+    .tab .badge.err { background: var(--vscode-errorForeground, #f48771); color: #fff; }
+    .tab .spin { margin-left: 0.35em; color: var(--vscode-textLink-foreground); }
+    .tab .spin.hidden { display: none; }
+    .panel { padding: 0.6em 0.8em; display: none; }
+    .panel.active { display: block; }
+
     .section { margin-bottom: 1em; }
     .section-title {
 	font-family: var(--vscode-font-family, sans-serif);
@@ -251,33 +398,32 @@ export class InfoViewProvider implements vscode.Disposable {
 	border-bottom: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.35));
 	padding-bottom: 0.2em;
     }
-    /* Context entries laid out as a grid so the bar separators line up; the
-       part before the bar is right-aligned, the refinement after it left-aligned. */
+    /* Context entries laid out as a left-aligned grid so that every column —
+       including the refinement predicates after the bar — starts at the same x,
+       aligning refinements together on the left. */
     .bindings {
 	display: grid;
-	grid-template-columns: max-content max-content minmax(0, max-content);
+	grid-template-columns: max-content max-content max-content max-content minmax(0, 1fr);
+	column-gap: 0.35em;
 	row-gap: 0.15em;
 	align-items: baseline;
+	text-align: left;
     }
-    .b-lhs { text-align: right; white-space: pre; }
-    .b-bar { color: var(--vscode-descriptionForeground); padding: 0 0.5em; }
+    .b-name { white-space: pre; }
+    .b-colon { color: var(--vscode-descriptionForeground); }
+    .b-type { white-space: pre; }
+    .b-bar { color: var(--vscode-descriptionForeground); }
     .b-pred { overflow-wrap: anywhere; }
     .name { color: var(--vscode-symbolIcon-variableForeground, var(--vscode-editor-foreground)); }
-    .colon { color: var(--vscode-descriptionForeground); }
     .type { color: var(--vscode-symbolIcon-typeParameterForeground, var(--vscode-textLink-foreground)); }
     .pred { color: var(--vscode-editor-foreground); }
-    /* One conjunct per line (with a trailing && on all but the last); each
-       line takes a subtle, theme-aware highlight on hover. */
     .conj { text-align: left; border-radius: 3px; padding: 0 0.3em; }
     .conj:hover { background: var(--vscode-list-hoverBackground, rgba(128,128,128,0.18)); }
     .conj .op { color: var(--vscode-descriptionForeground); }
-    .turnstile { margin: 0.15em 0; word-break: break-word; font-weight: 600; }
+    .turnstile { margin: 0.15em 0; word-break: break-word; font-weight: 600; text-align: left; }
     .turnstile .turn { color: var(--vscode-symbolIcon-functionForeground, var(--vscode-textLink-activeForeground)); padding-right: 0.3em; }
     .turnstile .bar { color: var(--vscode-descriptionForeground); padding: 0 0.3em; font-weight: normal; }
     .turnstile .pred { font-weight: normal; display: inline-block; vertical-align: top; }
-    .diagnostic { margin: 0.15em 0; white-space: pre-wrap; }
-    .diagnostic.error { color: var(--vscode-errorForeground, #f48771); }
-    .diagnostic.warning { color: var(--vscode-editorWarning-foreground, #cca700); }
     details.globals summary {
 	cursor: pointer;
 	color: var(--vscode-descriptionForeground);
@@ -285,21 +431,80 @@ export class InfoViewProvider implements vscode.Disposable {
 	margin-bottom: 0.3em;
     }
     .empty { color: var(--vscode-descriptionForeground); font-style: italic; }
-    /* Live synthesis progress (separate, server-pushed region). */
-    .synthesis { margin-bottom: 1em; }
-    .syn-algo {
-	font-family: var(--vscode-font-family, sans-serif);
-	color: var(--vscode-editor-foreground);
-	margin-bottom: 0.25em;
+
+    /* --- errors ----------------------------------------------------------- */
+    .error-item { margin-bottom: 1.2em; }
+    .error-msg { white-space: pre-wrap; margin-bottom: 0.35em; }
+    .error-item.error .error-msg { color: var(--vscode-errorForeground, #f48771); }
+    .error-item.warning .error-msg { color: var(--vscode-editorWarning-foreground, #cca700); }
+    .cex {
+	margin: 0.25em 0 0.4em;
+	padding: 0.25em 0.5em;
+	border-left: 3px solid var(--vscode-errorForeground, #f48771);
+	background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.12));
+	overflow-wrap: anywhere;
     }
-    .syn-algo .done { color: var(--vscode-testing-iconPassed, #4caf50); }
-    .syn-algo .spin { color: var(--vscode-descriptionForeground); }
-    .syn-stats {
+    .cex .label {
+	font-family: var(--vscode-font-family, sans-serif);
+	font-size: 0.8em;
+	color: var(--vscode-descriptionForeground);
+	margin-right: 0.4em;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+    }
+    .cex .value { color: var(--vscode-editor-foreground); font-weight: 600; }
+    .vc-label {
+	font-family: var(--vscode-font-family, sans-serif);
+	font-size: 0.8em;
+	color: var(--vscode-descriptionForeground);
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	margin: 0.3em 0 0.15em;
+    }
+    pre.vc {
+	margin: 0;
+	padding: 0.35em 0.5em;
+	white-space: pre;
+	overflow-x: auto;
+	background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.12));
+	border-radius: 3px;
+    }
+    details.vc-step { margin-top: 0.25em; }
+    details.vc-step > summary {
+	cursor: pointer;
+	color: var(--vscode-textLink-foreground);
+	font-family: var(--vscode-font-family, sans-serif);
+	font-size: 0.82em;
+	margin: 0.25em 0;
+	list-style: none;
+    }
+    details.vc-step > summary::before { content: '▸ '; }
+    details.vc-step[open] > summary::before { content: '▾ '; }
+    details.vc-step { border-left: 1px dashed var(--vscode-panel-border, rgba(128,128,128,0.4)); padding-left: 0.5em; }
+
+    /* --- synthesis -------------------------------------------------------- */
+    .syn-header { font-family: var(--vscode-font-family, sans-serif); margin-bottom: 0.5em; }
+    .syn-header .hole { color: var(--vscode-symbolIcon-functionForeground, var(--vscode-textLink-foreground)); font-weight: 600; }
+    .syn-list { display: flex; flex-direction: column; gap: 0.25em; }
+    .syn-run {
+	text-align: left;
 	font-family: var(--vscode-font-family, sans-serif);
 	font-size: 0.9em;
-	color: var(--vscode-descriptionForeground);
-	margin-bottom: 0.35em;
+	background: var(--vscode-button-secondaryBackground, rgba(128,128,128,0.15));
+	color: var(--vscode-button-secondaryForeground, var(--vscode-editor-foreground));
+	border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.35));
+	border-radius: 4px;
+	padding: 0.35em 0.6em;
+	cursor: pointer;
     }
+    .syn-run:hover { background: var(--vscode-button-secondaryHoverBackground, rgba(128,128,128,0.28)); }
+    .syn-run-icon { color: var(--vscode-textLink-foreground); margin-right: 0.35em; }
+    .synthesis { margin-bottom: 1em; }
+    .syn-progress { margin-bottom: 1em; }
+    .syn-algo { font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-editor-foreground); margin-bottom: 0.25em; }
+    .syn-algo .done { color: var(--vscode-testing-iconPassed, #4caf50); }
+    .syn-algo .spin { color: var(--vscode-descriptionForeground); }
+    .syn-stats { font-family: var(--vscode-font-family, sans-serif); font-size: 0.9em; color: var(--vscode-descriptionForeground); margin-bottom: 0.35em; }
     .syn-stats .num { color: var(--vscode-editor-foreground); font-weight: 600; }
     .syn-best {
 	white-space: pre-wrap;
@@ -309,42 +514,63 @@ export class InfoViewProvider implements vscode.Disposable {
 	padding: 0.2em 0.4em;
 	margin-bottom: 0.4em;
     }
-    .syn-best .label {
-	font-family: var(--vscode-font-family, sans-serif);
-	font-size: 0.8em;
-	color: var(--vscode-descriptionForeground);
-	display: block;
-    }
-    .syn-bar {
-	height: 6px;
-	border-radius: 3px;
-	background: rgba(128,128,128,0.25);
-	overflow: hidden;
-    }
-    .syn-bar-fill {
-	height: 100%;
-	background: var(--vscode-progressBar-background, var(--vscode-textLink-foreground));
-	transition: width 0.2s ease;
-    }
-    .syn-time {
-	font-size: 0.8em;
-	color: var(--vscode-descriptionForeground);
-	text-align: right;
-	margin-top: 0.15em;
-    }
+    .syn-best .label { font-family: var(--vscode-font-family, sans-serif); font-size: 0.8em; color: var(--vscode-descriptionForeground); display: block; }
+    .syn-bar { height: 6px; border-radius: 3px; background: rgba(128,128,128,0.25); overflow: hidden; }
+    .syn-bar-fill { height: 100%; background: var(--vscode-progressBar-background, var(--vscode-textLink-foreground)); transition: width 0.2s ease; }
+    .syn-time { font-size: 0.8em; color: var(--vscode-descriptionForeground); text-align: right; margin-top: 0.15em; }
 </style>
 </head>
 <body>
-<div id="synthesis"></div>
-<div id="content"><div class="empty">Place the cursor in an Aeon file.</div></div>
+<div class="tabs">
+    <button class="tab active" data-tab="errors">Errors<span class="badge" id="badge-errors" style="display:none"></span></button>
+    <button class="tab" data-tab="context">Context</button>
+    <button class="tab" data-tab="synthesis">Synthesis<span class="spin hidden" id="spin-synthesis">⟳</span></button>
+</div>
+<div class="location" id="location"></div>
+<div class="panel active" id="panel-errors"><div class="empty">Place the cursor in an Aeon file.</div></div>
+<div class="panel" id="panel-context"><div class="empty">Place the cursor in an Aeon file.</div></div>
+<div class="panel" id="panel-synthesis">
+    <div class="syn-progress" id="synthesis-progress"></div>
+    <div id="synthesis-list"><div class="empty">Place the cursor on a <code>?hole</code> to synthesize it.</div></div>
+</div>
 <script>
+    const vscode = acquireVsCodeApi();
+
+    function activate(tab) {
+	document.querySelectorAll('.tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tab));
+	document.querySelectorAll('.panel').forEach(p => p.classList.toggle('active', p.id === 'panel-' + tab));
+    }
+
+    document.querySelectorAll('.tab').forEach(t => {
+	t.addEventListener('click', () => activate(t.dataset.tab));
+    });
+
+    // Delegate clicks on synthesis "run" buttons to the extension.
+    document.getElementById('panel-synthesis').addEventListener('click', event => {
+	const btn = event.target.closest('.syn-run');
+	if (!btn) return;
+	vscode.postMessage({ type: 'synthesize', synthesizer: btn.dataset.synth });
+    });
+
+    function setBadge(count) {
+	const b = document.getElementById('badge-errors');
+	if (count > 0) { b.textContent = String(count); b.classList.add('err'); b.style.display = ''; }
+	else { b.style.display = 'none'; }
+    }
+
     window.addEventListener('message', event => {
 	const data = event.data;
 	if (!data) return;
 	if (data.kind === 'update') {
-	    document.getElementById('content').innerHTML = data.html;
-	} else if (data.kind === 'synthesis') {
-	    document.getElementById('synthesis').innerHTML = data.html;
+	    document.getElementById('location').textContent = data.location || '';
+	    document.getElementById('panel-errors').innerHTML = data.errors;
+	    document.getElementById('panel-context').innerHTML = data.context;
+	    document.getElementById('synthesis-list').innerHTML = data.synthesis;
+	    setBadge(data.errorCount || 0);
+	} else if (data.kind === 'synthesisProgress') {
+	    document.getElementById('synthesis-progress').innerHTML = data.html || '';
+	    document.getElementById('spin-synthesis').classList.toggle('hidden', !data.running);
+	    if (data.focus) activate('synthesis');
 	}
     });
 </script>
@@ -420,14 +646,16 @@ function predicateHtml(predicate: string): string {
 	.join('')
 }
 
-/** A grid of `name : type | predicate` rows. The grid columns make every `|`
- * line up; entries without a refinement leave the bar/predicate cells empty. */
+/** A left-aligned grid of `name : type | predicate` rows. Grid columns keep the
+ * bars and the refinement predicates aligned in a column on the left; entries
+ * without a refinement leave the bar/predicate cells empty. */
 function bindingTable(entries: InfoEntry[]): string {
     const rows = entries
 	.map(e => {
 	    const lhs =
-		`<div class="b-lhs"><span class="name">${esc(e.name)}</span>` +
-		`<span class="colon"> : </span><span class="type">${esc(e.type)}</span></div>`
+		`<div class="b-name"><span class="name">${esc(e.name)}</span></div>` +
+		`<div class="b-colon">:</div>` +
+		`<div class="b-type"><span class="type">${esc(e.type)}</span></div>`
 	    if (e.predicate) {
 		return lhs + `<div class="b-bar">|</div><div class="b-pred">${predicateHtml(e.predicate)}</div>`
 	    }
@@ -445,13 +673,49 @@ function turnstileHtml(target: { type: string; predicate: string | null }): stri
     return `<div class="turnstile"><span class="turn">⊢</span><span class="type">${esc(target.type)}</span>${pred}</div>`
 }
 
+/** An interactive view of a failing VC: the fully simplified form up front, and
+ * a nested chain of `<details>` that each reveal the VC as it was *before* the
+ * corresponding simplification step, back to the original. */
+function vcStepsHtml(steps: VCStep[]): string {
+    if (steps.length === 0) return ''
+    const final = steps[steps.length - 1]
+    const finalLabel = steps.length > 1 ? 'Simplified verification condition' : esc(final.label)
+    let html =
+	`<div class="vc-label">${finalLabel}</div>` +
+	`<pre class="vc">${esc(final.text)}</pre>`
+
+    // Build the nested "before <step>" disclosures from the outermost (the last
+    // simplification) inward to the original.
+    let inner = ''
+    for (let i = 1; i < steps.length; i++) {
+	const prev = steps[i - 1]
+	inner =
+	    `<details class="vc-step"><summary>before: ${esc(steps[i].label)}</summary>` +
+	    `<pre class="vc">${esc(prev.text)}</pre>${inner}</details>`
+    }
+    return html + inner
+}
+
+function errorHtml(e: ErrorInfo): string {
+    const cls = e.severity === 'warning' ? 'warning' : 'error'
+    const parts: string[] = [`<div class="error-msg">${esc(e.message)}</div>`]
+    if (e.counterexample) {
+	parts.push(
+	    `<div class="cex"><span class="label">Counterexample</span>` +
+		`<span class="value">${esc(e.counterexample)}</span></div>`,
+	)
+    }
+    if (e.vcSteps && e.vcSteps.length > 0) {
+	parts.push(vcStepsHtml(e.vcSteps))
+    }
+    return `<div class="error-item ${cls}">${parts.join('')}</div>`
+}
+
 /** Render the live synthesis progress region: algorithm, candidate counts,
  * best candidate so far, and a time progress bar (full on completion). */
-function synthesisHtml(s: SynthesisProgress): string {
-    const holeLabel = s.hole ? ` <span class="b-bar">·</span> ${esc(s.hole)}` : ''
-    const status = s.done
-	? '<span class="done">✓</span>'
-	: '<span class="spin">⟳</span>'
+function synthesisProgressHtml(s: SynthesisProgress): string {
+    const holeLabel = s.hole ? ` <span class="b-bar">·</span> ?${esc(s.hole)}` : ''
+    const status = s.done ? '<span class="done">✓</span>' : '<span class="spin">⟳</span>'
     const algo = `<div class="syn-algo">${status} ${esc(s.algorithm)}${holeLabel}</div>`
 
     const stats =
@@ -476,7 +740,7 @@ function synthesisHtml(s: SynthesisProgress): string {
 	    ? `<div class="syn-time">${s.elapsed.toFixed(1)}s / ${s.budget.toFixed(0)}s</div>`
 	    : ''
 
-    return section('Synthesis', `<div class="synthesis">${algo}${stats}${best}${bar}${time}</div>`)
+    return section('Running', `<div class="synthesis">${algo}${stats}${best}${bar}${time}</div>`)
 }
 
 function diagnosticsAt(document: vscode.TextDocument, position: vscode.Position): vscode.Diagnostic[] {
@@ -487,5 +751,5 @@ function diagnosticsAt(document: vscode.TextDocument, position: vscode.Position)
 
 function diagnosticHtml(d: vscode.Diagnostic): string {
     const cls = d.severity === vscode.DiagnosticSeverity.Error ? 'error' : 'warning'
-    return `<div class="diagnostic ${cls}">${esc(d.message)}</div>`
+    return `<div class="error-item ${cls}"><div class="error-msg">${esc(d.message)}</div></div>`
 }


### PR DESCRIPTION
## Summary
- Restructure the Aeon info view webview into **three tabs** backed by the enriched `aeon/infoView` LSP payload (see companion PR in `alcides/aeon`).
- **Errors**: counterexamples and an interactive, expandable view of the failing VC's simplification chain — each step reveals the version before that simplification, back to the original.
- **Context**: locals, goal (`⊢`) and globals, left-aligned with refinement predicates aligned in their own column.
- **Synthesis**: when the cursor is on a `?hole`, lists the available synthesis algorithms (click to run) and shows live search progress.
- Run buttons dispatch the `aeon.synthesize` server command via `workspace/executeCommand`.

## Test plan
- [ ] `npm run compile` builds the extension bundle without errors.
- [ ] `tsc --noEmit` reports no `src/` type errors.
- [ ] Manually: open an Aeon file, toggle the info view, and verify the three tabs render (errors with expandable VC steps, context table, synthesis list on a hole).

Requires the matching server change in `alcides/aeon` (`feat/vc-error-goal-first`) that adds `errors[]`, `hole`, and `synthesizers[]` to the `aeon/infoView` response.

Made with [Cursor](https://cursor.com)