### PR TITLE
Rename Exhaustive synthesizer family to Enumerative

### DIFF
--- a/vscode-aeon/src/infoview/infoViewProvider.ts
+++ b/vscode-aeon/src/infoview/infoViewProvider.ts
@@ -74,7 +74,7 @@ const INFOVIEW_REQUEST = 'aeon/infoView'
 const SYNTHESIZE_COMMAND = 'aeon.synthesize'
 const DEBOUNCE_MS = 150
 /** Display order for synthesis families in the Synthesis tab. */
-const SYNTH_FAMILY_ORDER = ['Exhaustive', 'Random', 'Evolutionary', 'LLM'] as const
+const SYNTH_FAMILY_ORDER = ['Enumerative', 'Random', 'Evolutionary', 'LLM'] as const
 /** Keep a finished synthesis result visible this long before clearing it. */
 const SYNTHESIS_CLEAR_MS = 12000
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames the synthesizer **family** label `Exhaustive` to `Enumerative` in the Synthesis tab of the info view.

## Details

The Synthesis tab groups the available synthesizers by family and renders them in a fixed display order defined by `SYNTH_FAMILY_ORDER` in `vscode-aeon/src/infoview/infoViewProvider.ts`. This changes the first entry from `Exhaustive` to `Enumerative`:

```ts
const SYNTH_FAMILY_ORDER = ['Enumerative', 'Random', 'Evolutionary', 'LLM'] as const
```

This matches the underlying `enumerative` synthesis backend naming.

> Note: the `family` value for each synthesizer is provided by the Aeon language server; for the group to sort into this position (rather than being appended as an "unknown" family), the server should report the family as `Enumerative` as well.

## Testing

- `npm run compile` succeeds.
- `npm run lint` fails due to a pre-existing missing ESLint v9 config (`eslint.config.js`), unrelated to this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b2b2fd5-0d39-495a-a976-6d2707115558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b2b2fd5-0d39-495a-a976-6d2707115558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

